### PR TITLE
Fixes #1. Added support for 0.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>net.unit8.maven.plugins</groupId>
     <artifactId>elm-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 
     <name>elm-maven-plugin</name>
     <url>https://github.com/kawasima/elm-maven-plugin</url>

--- a/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstaller.java
+++ b/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstaller.java
@@ -20,12 +20,14 @@ public class ElmInstaller {
 
     private static final Object LOCK = new Object();
 
-    private static final String ELM_ROOT_DIRECTORY = "dist";
     private static final String TAR_GZ = "tar.gz";
     private static final String GZ = "gz";
     private static final String ELM_VERSION_0_19_0 = "0.19.0";
 
-    private String elmVersion, elmDownloadRoot, userName, password;
+    private String elmVersion;
+    private String elmDownloadRoot;
+    private String userName;
+    private String password;
 
     private final Logger logger;
 
@@ -210,6 +212,9 @@ public class ElmInstaller {
             GzipCompressorInputStream inputStream = new GzipCompressorInputStream(fis);
             final File destPath = new File(destinationDirectory + File.separator + "elm");
             Files.copy(inputStream, destPath.toPath());
+            if (!destPath.setExecutable(true)) {
+                throw new IOException(("Could not set the destination to be executable."));
+            }
         } catch (IOException e) {
             logger.error("Failed to get Elm ", e);
         }

--- a/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
+++ b/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
@@ -1,5 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -7,7 +8,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ElmInstallerTest {
     private static final Platform defaultPlatform = Platform.guess();
@@ -16,9 +18,9 @@ class ElmInstallerTest {
     @Test
     void test() throws InstallationException, IOException {
         final InstallConfig installConfig = new DefaultInstallConfig(
-                new File(".").getCanonicalFile(),
-                new File(".").getCanonicalFile(),
-                new DirectoryCacheResolver(new File(".", DEFAULT_CACHE_PATH)),
+                new File("target").getCanonicalFile(),
+                new File("target").getCanonicalFile(),
+                new DirectoryCacheResolver(new File("target/", DEFAULT_CACHE_PATH)),
                 defaultPlatform
         );
 

--- a/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
+++ b/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,9 +14,60 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ElmInstallerTest {
     private static final Platform defaultPlatform = Platform.guess();
     private static final String DEFAULT_CACHE_PATH = "cache";
+    private static final String ELM_VERSION_19_0 = "0.19.0";
+    private static final String ELM_VERSION_19_1 = "0.19.1";
+    private static final String ELM_DOWNLOAD_ROOT = ElmInstaller.DEFAULT_ELM_DOWNLOAD_ROOT;
+    private static final String TARGET_NODE_ELM_ELM = "target/node/elm/elm";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        File file = new File(TARGET_NODE_ELM_ELM);
+        if (file.exists()) {
+            Files.delete(file.toPath());
+        }
+    }
 
     @Test
-    void test() throws InstallationException, IOException {
+    void test_install_0_19_0() throws InstallationException, IOException {
+        final ElmInstaller elmInstaller = getElmInstaller();
+        elmInstaller.setElmVersion(ELM_VERSION_19_0);
+        elmInstaller.install();
+
+        assertTrue(new File(TARGET_NODE_ELM_ELM).exists());
+    }
+
+    @Test
+    void test_install_0_19_1() throws InstallationException, IOException {
+        final ElmInstaller elmInstaller = getElmInstaller();
+        elmInstaller.setElmVersion(ELM_VERSION_19_1);
+        elmInstaller.install();
+
+        assertTrue(new File(TARGET_NODE_ELM_ELM).exists());
+    }
+
+    @Test
+    void downLoadUrlForVersion19_0() throws IOException {
+        final ElmInstaller elmInstaller = getElmInstaller();
+        elmInstaller.setElmVersion(ELM_VERSION_19_0);
+        String platform = elmInstaller.getPlatform();
+
+        String downloadUrl = elmInstaller.getDownloadUrl(ELM_DOWNLOAD_ROOT, ELM_VERSION_19_0);
+
+        assertEquals(ELM_DOWNLOAD_ROOT + ELM_VERSION_19_0 + "/binaries-for-" + platform + ".tar.gz", downloadUrl);
+    }
+
+    @Test
+    void downLoadUrlForVersion19_1() throws IOException {
+        final ElmInstaller elmInstaller = getElmInstaller();
+        elmInstaller.setElmVersion(ELM_VERSION_19_1);
+        String platform = elmInstaller.getPlatform();
+
+        String downloadUrl = elmInstaller.getDownloadUrl(ELM_DOWNLOAD_ROOT, ELM_VERSION_19_1);
+
+        assertEquals(ELM_DOWNLOAD_ROOT + ELM_VERSION_19_1 + "/binary-for-" + platform + "-64-bit.gz", downloadUrl);
+    }
+
+    private ElmInstaller getElmInstaller() throws IOException {
         final InstallConfig installConfig = new DefaultInstallConfig(
                 new File("target").getCanonicalFile(),
                 new File("target").getCanonicalFile(),
@@ -25,11 +76,8 @@ class ElmInstallerTest {
         );
 
         final DefaultArchiveExtractor archiveExtractor = new DefaultArchiveExtractor();
-        final ProxyConfig proxyConfig = new ProxyConfig(new ArrayList<ProxyConfig.Proxy>());
+        final ProxyConfig proxyConfig = new ProxyConfig(new ArrayList<>());
         final DefaultFileDownloader fileDownloader = new DefaultFileDownloader(proxyConfig);
-        final ElmInstaller elmInstaller = new ElmInstaller(installConfig, archiveExtractor, fileDownloader);
-        elmInstaller.setElmVersion("0.19.0");
-        elmInstaller.install();
+        return new ElmInstaller(installConfig, archiveExtractor, fileDownloader);
     }
-
 }

--- a/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
+++ b/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ElmInstallerTest.java
@@ -33,7 +33,9 @@ class ElmInstallerTest {
         elmInstaller.setElmVersion(ELM_VERSION_19_0);
         elmInstaller.install();
 
-        assertTrue(new File(TARGET_NODE_ELM_ELM).exists());
+        File file = new File(TARGET_NODE_ELM_ELM);
+        assertTrue(file.exists());
+        assertTrue(file.canExecute());
     }
 
     @Test
@@ -42,7 +44,9 @@ class ElmInstallerTest {
         elmInstaller.setElmVersion(ELM_VERSION_19_1);
         elmInstaller.install();
 
-        assertTrue(new File(TARGET_NODE_ELM_ELM).exists());
+        File file = new File(TARGET_NODE_ELM_ELM);
+        assertTrue(file.exists());
+        assertTrue(file.canExecute());
     }
 
     @Test


### PR DESCRIPTION
Starting with version 0.19.1, the compiler is stored at a new path in a new format.

Hope this is valuable to you. I really like to use this plugin.